### PR TITLE
Ignoring "+" characters in the middle of the message

### DIFF
--- a/src/helpers/transfer.ts
+++ b/src/helpers/transfer.ts
@@ -66,7 +66,7 @@ async function checkTransfer(ctx: ContextMessageUpdate) {
     }
   } else if (ctx.message && ctx.message.text) {
     // Get number of coins to send
-    amount = (ctx.message.text.match(/\+/g) || []).length
+    amount = ctx.message.text.match(/^\+{1,}/g)?.[0].length ?? 0
     const heartAmount = contains(ctx.message.text, '<3')
     const emojiAmount = contains(ctx.message.text, '❤️')
     const bowlAmount = contains(ctx.message.text, '🥣')


### PR DESCRIPTION
Now amount of memcoins transferred is equal to number of "+" characters at the start of the message.

So:
"++++, this is a cool idea!" -- awards 4 memcoins
"2 + 2 = 4" -- no memcoins
"I'm looking for a developer with 10+ years of experience" -- no memcoins